### PR TITLE
Replace pavucontrol w/ pipewire-native pwvucontrol

### DIFF
--- a/modules/audio/pipewire.nix
+++ b/modules/audio/pipewire.nix
@@ -16,7 +16,7 @@
       { pkgs, ... }:
       {
         home.packages = with pkgs; [
-          pavucontrol
+          pwvucontrol
           qpwgraph
         ];
       };


### PR DESCRIPTION
Hi, @mightyiam!

I was reviewing your flake, looking for enlightenment, and I saw that you were still using the pulseaudio volume control app, instead of the pipewire-native one¹ that has been available for some time now.

So, in case this was not intentional, here's my iota of a contribution :stuck_out_tongue_winking_eye:.

Didn't know about `qpwgraph`, which I have now adopted, thanks for that!

Happy hacking!

¹: See https://github.com/saivert/pwvucontrol